### PR TITLE
Add basic local Lie group visualization example

### DIFF
--- a/local_lie_group/__init__.py
+++ b/local_lie_group/__init__.py
@@ -1,0 +1,5 @@
+"""Local Lie group visualization package."""
+
+from .visualization import show_example
+
+__all__ = ["show_example"]

--- a/local_lie_group/visualization.py
+++ b/local_lie_group/visualization.py
@@ -1,0 +1,32 @@
+"""Visualization utilities for local Lie group examples."""
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401  # needed for 3D projection
+
+
+def show_example():
+    """Display a coordinate frame and a 3D point side by side."""
+    fig = plt.figure(figsize=(10, 5))
+
+    # Left: coordinate frame
+    ax_frame = fig.add_subplot(1, 2, 1, projection="3d")
+    length = 1.0
+    ax_frame.quiver(0, 0, 0, length, 0, 0, color="r", linewidth=2)
+    ax_frame.quiver(0, 0, 0, 0, length, 0, color="g", linewidth=2)
+    ax_frame.quiver(0, 0, 0, 0, 0, length, color="b", linewidth=2)
+    ax_frame.set_xlim([-1, 1])
+    ax_frame.set_ylim([-1, 1])
+    ax_frame.set_zlim([-1, 1])
+    ax_frame.set_title("Coordinate Frame")
+
+    # Right: 3D point
+    ax_point = fig.add_subplot(1, 2, 2, projection="3d")
+    ax_point.scatter([0.5], [0.5], [0.5], color="k", s=50)
+    ax_point.set_xlim([-1, 1])
+    ax_point.set_ylim([-1, 1])
+    ax_point.set_zlim([-1, 1])
+    ax_point.set_title("3D Point")
+
+    plt.tight_layout()
+    plt.show()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,6 @@
+"""Run the local Lie group visualization example."""
+from local_lie_group import show_example
+
+
+if __name__ == "__main__":
+    show_example()


### PR DESCRIPTION
## Summary
- add `local_lie_group` package with visualization utilities
- provide `main.py` script to display a coordinate frame and a 3D point

## Testing
- `python main.py` *(fails: ModuleNotFoundError: No module named 'matplotlib')*


------
https://chatgpt.com/codex/tasks/task_e_68b561e348f083278c7a7ee0e8905514